### PR TITLE
Simplify tmuxline (remove much utf-8).

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -70,15 +70,15 @@ set -g status-right-fg black
 set -g status-right-attr bold
 set -g status-right '#[fg=colour214,bg=colour235] #I #[fg=white,bg=colour236] #W #[default]'
 
-# make background window look like white tab
+# make background window look like pale white tab
 set-window-option -g window-status-bg default
 set-window-option -g window-status-fg white
 set-window-option -g window-status-attr none
-set-window-option -g window-status-format '#[fg=colour214,bg=colour235] #I #[fg=white,bg=colour236] #W #[default]'
+set-window-option -g window-status-format '#[fg=colour250,bg=colour236] #I|#[fg=white,bg=colour236]#W  #[default]'
 
-# make foreground window look like bold yellow foreground tab
+# make foreground window look like bright foreground tab
 set-window-option -g window-status-current-attr none
-set-window-option -g window-status-current-format '#[fg=black,bg=colour214] #I #[fg=brightwhite,bg=colour238] #W #[default]'
+set-window-option -g window-status-current-format '#[fg=colour209,bg=colour239] #I|#[fg=colour255,bg=colour239]#W #[default]'
 
 # active terminal yellow border, non-active white
 set -g pane-border-bg default

--- a/tmuxline.conf
+++ b/tmuxline.conf
@@ -23,7 +23,7 @@ setw -g window-status-activity-attr "none"
 setw -g window-status-activity-fg "colour109"
 setw -g window-status-separator ""
 setw -g window-status-bg "colour236"
-set -g status-left "#[fg=colour235,bg=colour109,bold] #S #[fg=colour109,bg=colour236,nobold,nounderscore,noitalics]"
-set -g status-right "#[fg=colour239,bg=colour236,nobold,nounderscore,noitalics]#[fg=colour254,bg=colour239] %Y-%m-%d  %H:%M #[fg=colour109,bg=colour239,nobold,nounderscore,noitalics]#[fg=colour235,bg=colour109] #h "
-setw -g window-status-format "#[fg=colour254,bg=colour236] #I #[fg=colour254,bg=colour236] #W "
-setw -g window-status-current-format "#[fg=colour236,bg=colour239,nobold,nounderscore,noitalics]#[fg=colour254,bg=colour239] #I #[fg=colour254,bg=colour239] #W #[fg=colour239,bg=colour236,nobold,nounderscore,noitalics]"
+set -g status-left "#[fg=colour235,bg=colour109,bold] #S #[fg=colour109,bg=colour236,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=colour239,bg=colour236,nobold,nounderscore,noitalics]#[fg=colour254,bg=colour239] %Y-%m-%d %H:%M #[fg=colour109,bg=colour239,nobold,nounderscore,noitalics] #[fg=colour235,bg=colour109] #h "
+setw -g window-status-format '#[fg=colour250,bg=colour236] #I|#[fg=white,bg=colour236]#W  #[default]'
+setw -g window-status-current-format '#[fg=colour209,bg=colour239] #I|#[fg=colour255,bg=colour239]#W #[default]'

--- a/vimrc
+++ b/vimrc
@@ -112,7 +112,6 @@ Plugin 'vim-ruby/vim-ruby'
 Plugin 'pangloss/vim-javascript'
 Plugin 'elixir-lang/vim-elixir'
 Plugin 'tpope/vim-rails'
-" Plugin 'jlanzarotta/bufexplorer'
 Plugin 'crookedneighbor/bufexplorer'
 Plugin 'pgr0ss/vimux-ruby-test'
 Plugin 'plasticboy/vim-markdown'
@@ -122,17 +121,10 @@ Plugin 'tpope/vim-fugitive'
 Plugin 'tpope/vim-surround'
 Plugin 'jgdavey/vim-turbux'
 Plugin 'epmatsw/ag.vim'
-Plugin 'bling/vim-airline'
 Plugin 'groenewege/vim-less'
 Plugin 'ekalinin/Dockerfile.vim'
 Plugin 'mattn/emmet-vim'
-
-" Plugin 'suan/vim-instant-markdown'
-" let g:instant_markdown_slow = 1
-
 Plugin 'edkolev/tmuxline.vim'
-let g:airline_powerline_fonts = 1 
-
 Plugin 'fatih/vim-go'
 let g:go_highlight_operators = 1
 let g:go_highlight_functions = 1


### PR DESCRIPTION
Would like to use a simpler and more cross-platform config for tmuxline. The previous was unstable/unusable on gnome terminal. 
