### PR TITLE
Python config

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -4,9 +4,9 @@ set-option -g default-shell /bin/zsh
 # split windows like vim
 # vim's definitoin of a horizontal/vertical split is reversed from tmux's
 bind s split-window -v -c "#{pane_current_path}"
-bind '%' split-window -v -c "#{pane_current_path}"
-bind v split-window -h -c "#{pane_current_path}"
 bind '"' split-window -v -c "#{pane_current_path}"
+bind v split-window -h -c "#{pane_current_path}"
+bind '%' split-window -h -c "#{pane_current_path}"
 
 bind ^s split-window -v -c "#{pane_current_path}"
 bind ^v split-window -h -c "#{pane_current_path}"

--- a/vimrc
+++ b/vimrc
@@ -117,6 +117,7 @@ Plugin 'elixir-lang/vim-elixir'
 Plugin 'tpope/vim-rails'
 Plugin 'crookedneighbor/bufexplorer'
 Plugin 'pgr0ss/vimux-ruby-test'
+Plugin 'pitluga/vimux-nose-test'
 Plugin 'plasticboy/vim-markdown'
 Plugin 'tpope/vim-endwise'
 Plugin 'jtratner/vim-flavored-markdown'
@@ -154,7 +155,12 @@ map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 Plugin 'benmills/vimux'
 Plugin 'benmills/vimux-golang'
 let g:VimuxUseNearestPane = 1
+map <silent> <LocalLeader>rp :wa<CR> :VimuxRunCommand('python ' . shellescape(@%, 1) )<CR>
+map <silent> <LocalLeader>rr :wa<CR> :VimuxRunCommand('ruby ' . shellescape(@%, 1) )<CR>
+map <silent> <LocalLeader>rs :wa<CR> :VimuxRunCommand('$SHELL ' . shellescape(@%, 1) )<CR>
 map <silent> <LocalLeader>rl :wa<CR> :VimuxRunLastCommand<CR>
+map <silent> <LocalLeader>rb :wa<CR> :RunAllNoseTests<CR>
+map <silent> <LocalLeader>rf :wa<CR> :RunFocusedNoseTests<CR>
 map <silent> <LocalLeader>vi :wa<CR> :VimuxInspectRunner<CR>
 map <silent> <LocalLeader>vk :wa<CR> :VimuxInterruptRunner<CR>
 map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>

--- a/vimrc
+++ b/vimrc
@@ -82,7 +82,7 @@ autocmd FileType ruby runtime ruby_mappings.vim
 autocmd FileType yml setlocal filetype=yaml
 
 " Autoremove trailing spaces when saving the buffer
-autocmd FileType c,cpp,elixir,eruby,html,ghmarkdown,go,java,javascript,json,less,md,php,ruby,yaml autocmd BufWritePre <buffer> :%s/\s\+$//e
+autocmd FileType c,cpp,elixir,eruby,html,ghmarkdown,go,java,javascript,json,less,md,php,python,ruby,yaml autocmd BufWritePre <buffer> :%s/\s\+$//e
 
 
 " Fix indenting for html files

--- a/vimrc
+++ b/vimrc
@@ -167,6 +167,11 @@ map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>
 map <silent> <LocalLeader>vp :VimuxPromptCommand<CR>
 vmap <silent> <LocalLeader>vs "vy :call VimuxRunCommand(@v)<CR>
 nmap <silent> <LocalLeader>vs vip<LocalLeader>vs<CR>
+"  === Custom test suites ===
+"  Use `alias vim_test_integration='your config'` and `alias vim_test_unit='your config'`
+"  This provides a linkable way to define custom, complex test suite configurations
+map <silent> <LocalLeader>ri :wa<CR> :VimuxRunCommand('vim_test_integration')<CR>
+map <silent> <LocalLeader>ru :wa<CR> :VimuxRunCommand('vim_test_unit')<CR>
 
 Plugin 'kien/ctrlp.vim'
 let g:ctrlp_show_hidden = 1

--- a/vimrc
+++ b/vimrc
@@ -175,6 +175,7 @@ let g:ctrlp_match_window_reversed = 0
 map <silent> <LocalLeader>mr :CtrlPMRU<CR>
 map <silent> <C-p><C-b> :CtrlPBuffer<CR>
 map <silent> <leader>ff :CtrlP<CR>
+map <silent> <leader>fr :CtrlPClearCache<CR>
 
 Plugin 'mileszs/ack.vim'
 let g:AckAllFiles = 0


### PR DESCRIPTION
I did some python development today and found a few issues. The commits are fairly self-explanatory and minor.

One idea that isn't: Creating `leader-ru` and `leader-ri` shortcuts to call out for custom unit and integration test configs. This lets you alias those custom configurations in aliases and get a handle with this shortcut.